### PR TITLE
Fix: 특정 예약에서 변경 가능한 차량 리스트를 가져오는 기능 수정

### DIFF
--- a/src/main/java/com/yu/yurentcar/domain/branch/service/BranchService.java
+++ b/src/main/java/com/yu/yurentcar/domain/branch/service/BranchService.java
@@ -3,7 +3,9 @@ package com.yu.yurentcar.domain.branch.service;
 import com.yu.yurentcar.domain.branch.dto.UpdatableCarListRequestParamsDto;
 import com.yu.yurentcar.domain.branch.dto.UpdatableCarResponseDto;
 import com.yu.yurentcar.domain.branch.repository.BranchRepository;
+import com.yu.yurentcar.domain.car.dto.CarManagementDto;
 import com.yu.yurentcar.domain.car.repository.CarRepository;
+import com.yu.yurentcar.domain.car.service.CarService;
 import com.yu.yurentcar.domain.user.repository.AdminRepository;
 import com.yu.yurentcar.global.SiDoType;
 import com.yu.yurentcar.global.utils.enums.EnumValueConvertUtils;
@@ -13,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Log4j2
 @Service
@@ -20,11 +23,13 @@ public class BranchService {
     private final CarRepository carRepository;
     private final BranchRepository branchRepository;
     private final AdminRepository adminRepository;
+    private final CarService carService;
 
-    public BranchService(CarRepository carRepository, BranchRepository branchRepository, AdminRepository adminRepository) {
+    public BranchService(CarRepository carRepository, BranchRepository branchRepository, AdminRepository adminRepository, CarService carService) {
         this.carRepository = carRepository;
         this.branchRepository = branchRepository;
         this.adminRepository = adminRepository;
+        this.carService = carService;
     }
 
     @Transactional(readOnly = true)
@@ -50,6 +55,17 @@ public class BranchService {
         if (!isReservationInAdminBranch)
             throw new RuntimeException("해당 관리자가 없거나 해당 관리자 지점의 예약이 아닙니다.");
 
-        return carRepository.findUpdatableCarListByDateAndReservationId(requestDto.getStartDate(), requestDto.getEndDate(), requestDto.getReservationId());
+        List<CarManagementDto> carNumberListInReservationBranch = carService.getCarListByAdmin(requestDto.getAdminUsername());
+        return carNumberListInReservationBranch.stream()
+                .filter((car) ->
+                        carRepository.updatableByCarNumberAndDate(
+                                requestDto.getReservationId(),
+                                car.getCarNumber(),
+                                requestDto.getStartDate(),
+                                requestDto.getEndDate()
+                        )
+                )
+                .map((car) -> new UpdatableCarResponseDto(car.getCarName(), car.getCarNumber()))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/yu/yurentcar/domain/car/repository/CarRepositoryCustom.java
+++ b/src/main/java/com/yu/yurentcar/domain/car/repository/CarRepositoryCustom.java
@@ -1,6 +1,5 @@
 package com.yu.yurentcar.domain.car.repository;
 
-import com.yu.yurentcar.domain.branch.dto.UpdatableCarResponseDto;
 import com.yu.yurentcar.domain.car.dto.*;
 
 import java.time.LocalDateTime;
@@ -25,6 +24,4 @@ public interface CarRepositoryCustom {
     List<CarResponseDto> findCarsByCarNumbers(String[] carNumber);
 
     List<CarManagementDto> findCarsByAdmin(String adminUsername);
-
-    List<UpdatableCarResponseDto> findUpdatableCarListByDateAndReservationId(LocalDateTime startDate, LocalDateTime endDate, Long reservationId);
 }

--- a/src/main/java/com/yu/yurentcar/domain/car/repository/CarRepositoryImpl.java
+++ b/src/main/java/com/yu/yurentcar/domain/car/repository/CarRepositoryImpl.java
@@ -4,10 +4,8 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.yu.yurentcar.domain.branch.dto.UpdatableCarResponseDto;
 import com.yu.yurentcar.domain.branch.repository.BranchRepository;
 import com.yu.yurentcar.domain.car.dto.*;
-import com.yu.yurentcar.domain.car.entity.Car;
 import com.yu.yurentcar.domain.car.entity.QCarSpecification;
 import com.yu.yurentcar.global.SiDoType;
 import lombok.RequiredArgsConstructor;
@@ -191,32 +189,6 @@ public class CarRepositoryImpl implements CarRepositoryCustom {
                 .select(Projections.constructor(CarManagementDto.class, car.carSpec.carName, car.carNumber, car.carState, car.carId))
                 .from(car)
                 .where(car.branch.eq(branchRepository.findBranchByAdmin(adminUsername)))
-                .fetch();
-    }
-
-    @Override
-    public List<UpdatableCarResponseDto> findUpdatableCarListByDateAndReservationId(LocalDateTime startDate, LocalDateTime endDate, Long reservationId) {
-        JPAQuery<Car> carPath = queryFactory.select(reservation.car)
-                .from(reservation)
-                .where(reservation.reservationId.ne(reservationId))
-                .where(getUsableDateFilter(startDate, endDate));
-
-        JPAQuery<Car> carListInBranchPath = queryFactory.selectFrom(car)
-                .where(car.branch.eq(
-                        queryFactory.select(car.branch)
-                                .from(reservation)
-                                .innerJoin(reservation.car, car)
-                                .where(reservation.reservationId.eq(reservationId))
-                ));
-        return queryFactory
-                .select(Projections.constructor(UpdatableCarResponseDto.class,
-                        carSpec.carName, car.carNumber))
-                .from(car)
-                .innerJoin(car.carSpec, carSpec)
-                .where(car.ne(carPath))
-                .where(car.in(
-                        carListInBranchPath
-                ))
                 .fetch();
     }
 }

--- a/src/main/java/com/yu/yurentcar/domain/user/repository/AdminRepositoryImpl.java
+++ b/src/main/java/com/yu/yurentcar/domain/user/repository/AdminRepositoryImpl.java
@@ -16,7 +16,7 @@ public class AdminRepositoryImpl implements AdminRepositoryCustom {
 
     @Override
     public Boolean isReservationByAdminBranch(Long reservationId, String adminUsername) {
-        return queryFactory
+        return !queryFactory
                 .selectFrom(reservation)
                 .where(reservation.reservationId.eq(reservationId))
                 .where(reservation.car.branch.eq(


### PR DESCRIPTION
## 해결
- 지점과 예약이 일치하지 않는다는 버그
  - AdminRepositoryImpl
    - isReservationByAdminBranch에서 반대로 반환하고 있던점 수정
  ```java
    public Boolean isReservationByAdminBranch(Long reservationId, String adminUsername) {
        return !queryFactory
                .selectFrom(reservation)
                .where(reservation.reservationId.eq(reservationId))
                .where(reservation.car.branch.eq(
                        queryFactory.select(admin.branch)
                                .from(admin)
                                .where(admin.username.eq(adminUsername))
                ))
                .limit(1)
                .fetch().isEmpty();
    }
  ```
- 결과값이 해당 지점의 차량이 포함되지 않는 버그 수정
  - 복잡한 로직으로 쿼리의 버그로 사료됨
  - 정확하게 하나의 쿼리로 수정하는 것은 어렵다고 판단.
  - 기존에 사용 중이던 함수들을 활용하도록 수정
    - N+1 문제가 발생하므로 추후 더 고민해보기!!
    - 기존에 만든 함수 제거 후 Service에서 로직 추가
  ```java
  public List<UpdatableCarResponseDto> getUpdatableCarListByBranch(
                UpdatableCarListRequestParamsDto requestDto) {
    ...
      List<CarManagementDto> carNumberListInReservationBranch = carService
          .getCarListByAdmin(requestDto.getAdminUsername());
      return carNumberListInReservationBranch.stream()
              .filter((car) ->
                      carRepository.updatableByCarNumberAndDate(
                              requestDto.getReservationId(),
                              car.getCarNumber(),
                              requestDto.getStartDate(),
                              requestDto.getEndDate()
                      )
              )
              .map((car) -> new UpdatableCarResponseDto(car.getCarName(), car.getCarNumber()))
              .collect(Collectors.toList());
    }
  ```

- BranchService
  - carRepository.findUpdatableCarListByDateAndReservationId를 제거하고 기존 로직으로 대체
  - carService.getCarListByAdmin
  - carRepository.updatableByCarNumberAndDate로 필터링

close : #107