### PR TITLE
Fix: POST /api/v1/branches/notices 종료일이후 -> 전체로 로직 수정

### DIFF
--- a/src/main/java/com/yu/yurentcar/domain/branch/repository/NoticeRepositoryImpl.java
+++ b/src/main/java/com/yu/yurentcar/domain/branch/repository/NoticeRepositoryImpl.java
@@ -32,10 +32,8 @@ public class NoticeRepositoryImpl implements NoticeRepositoryCustom {
         JPAQuery<NoticeSummaryDto> query = queryFactory
                 .select(Projections.constructor(NoticeSummaryDto.class, notice.noticeId, notice.photoUrl, notice.title, notice.description, notice.startDate, notice.finishDate, notice.modifiedAt))
                 .from(notice)
-                .where(notice.branch.eq(queryFactory
-                                .selectFrom(branch)
-                                .where(branch.branchName.eq(branchName).and(branch.siDo.eq(siDo))))
-                        .and(notice.finishDate.gt(LocalDateTime.now()).or(notice.finishDate.isNull())))
+                .where(notice.branch.branchName.eq(branchName))
+                .where(notice.branch.siDo.eq(siDo))
                 .orderBy(notice.modifiedAt.desc());
         if(count != 0)
             query = query.limit(count);


### PR DESCRIPTION
- NoticeRepositoryImpl
  - `.and(notice.finishDate.gt(LocalDateTime.now()).or(notice.finishDate.isNull())))` 조건 제거
  ```java
  //기존
   JPAQuery<NoticeSummaryDto> query = queryFactory
                  .select(Projections.constructor(NoticeSummaryDto.class, notice.noticeId, notice.photoUrl, notice.title, notice.description, notice.startDate, notice.finishDate, notice.modifiedAt))
                  .from(notice)
                  .where(notice.branch.eq(queryFactory
                                  .selectFrom(branch)
                                  .where(branch.branchName.eq(branchName).and(branch.siDo.eq(siDo))))
                          .and(notice.finishDate.gt(LocalDateTime.now()).or(notice.finishDate.isNull())))
                  .orderBy(notice.modifiedAt.desc());
  ```
  ```java
  //개선
  JPAQuery<NoticeSummaryDto> query = queryFactory
                  .select(Projections.constructor(NoticeSummaryDto.class, notice.noticeId, notice.photoUrl, notice.title, notice.description, notice.startDate, notice.finishDate, notice.modifiedAt))
                  .from(notice)
                  .where(notice.branch.branchName.eq(branchName))
                  .where(notice.branch.siDo.eq(siDo))
                  .orderBy(notice.modifiedAt.desc());
  ```

Close : #140