### PR TITLE
Fix: 관리자 로그인 반환값 및 로직 변경

### DIFF
--- a/src/main/java/com/yu/yurentcar/domain/user/controller/AdminController.java
+++ b/src/main/java/com/yu/yurentcar/domain/user/controller/AdminController.java
@@ -1,12 +1,30 @@
 package com.yu.yurentcar.domain.user.controller;
 
+import com.yu.yurentcar.domain.user.dto.AdminAuthDto;
 import com.yu.yurentcar.domain.user.dto.AdminLoginDto;
+import com.yu.yurentcar.domain.user.dto.AdminLoginResponseDto;
+import com.yu.yurentcar.domain.user.entity.Admin;
 import com.yu.yurentcar.domain.user.service.AdminService;
+import com.yu.yurentcar.global.utils.CookieProvider;
+import com.yu.yurentcar.global.utils.TokenProvider;
+import com.yu.yurentcar.security.dto.LoginCookies;
+import com.yu.yurentcar.security.dto.TokenDto;
+import com.yu.yurentcar.security.service.TokenRedisService;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Collections;
 
 @Log4j2
 @RestController
@@ -14,11 +32,36 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("api/v1/admin")
 public class AdminController {
     private final AdminService adminService;
+    private final TokenProvider tokenProvider;
+    private final TokenRedisService tokenRedisService;
+    private final CookieProvider cookieProvider;
 
     @PostMapping("/login")
-    public ResponseEntity<Boolean> loginAdmin(@RequestBody AdminLoginDto adminLoginDto) {
+    public ResponseEntity<AdminLoginResponseDto> loginAdmin(HttpServletResponse response, @RequestBody AdminLoginDto adminLoginDto) {
         log.info("loginAdmin : " + adminLoginDto);
-        return ResponseEntity.status(HttpStatus.OK).body(adminService.loginAdmin(adminLoginDto));
+        Admin admin = adminService.loginAdmin(adminLoginDto);
+
+        AdminAuthDto adminAuth = new AdminAuthDto(
+                admin.getUsername(),
+                admin.getPassword(),
+                admin.getBranch().getBranchId(),
+                admin.getBranch().getBranchName(),
+                Collections.singleton(new SimpleGrantedAuthority("ROLE_ADMIN"))
+        );
+
+        Authentication newAuth = new UsernamePasswordAuthenticationToken(adminAuth, "", adminAuth.getAuthorities());
+        TokenDto token = tokenProvider.generateTokenDto(newAuth);
+        tokenRedisService.saveToken(token);
+
+        LoginCookies loginCookies = cookieProvider.makeLoginCookies(token);
+        response.addHeader(HttpHeaders.SET_COOKIE, loginCookies.getAccessCookie().toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, loginCookies.getRefreshCookie().toString());
+
+        return ResponseEntity.status(HttpStatus.OK).body(
+                AdminLoginResponseDto.builder()
+                        .branchName(admin.getBranch().getBranchName())
+                        .province(admin.getBranch().getSiDo().getDesc())
+                .build());
     }
 
 }

--- a/src/main/java/com/yu/yurentcar/domain/user/dto/AdminAuthDto.java
+++ b/src/main/java/com/yu/yurentcar/domain/user/dto/AdminAuthDto.java
@@ -1,0 +1,39 @@
+package com.yu.yurentcar.domain.user.dto;
+
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Map;
+
+@Log4j2
+@Getter
+@ToString
+public class AdminAuthDto extends User implements OAuth2User {
+    private final String username;
+    private String name;
+    private final Long branchId;
+    private final String branchName;
+    private Map<String, Object> attributes;
+
+    public AdminAuthDto(String username, String password, Long branchId, String branchName, Collection<? extends GrantedAuthority> authorities) {
+        super(username, password, authorities);
+        this.username = username;
+        this.branchId = branchId;
+        this.branchName = branchName;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return this.attributes;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+}

--- a/src/main/java/com/yu/yurentcar/domain/user/dto/AdminLoginResponseDto.java
+++ b/src/main/java/com/yu/yurentcar/domain/user/dto/AdminLoginResponseDto.java
@@ -1,0 +1,15 @@
+package com.yu.yurentcar.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor
+@Builder
+public class AdminLoginResponseDto {
+    private String branchName;
+    private String province;
+}

--- a/src/main/java/com/yu/yurentcar/domain/user/entity/Admin.java
+++ b/src/main/java/com/yu/yurentcar/domain/user/entity/Admin.java
@@ -34,7 +34,7 @@ public class Admin extends BaseTimeEntity {
     @Column(length = 64)
     private String password;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "branch_id")
     private Branch branch;
 

--- a/src/main/java/com/yu/yurentcar/domain/user/service/AdminService.java
+++ b/src/main/java/com/yu/yurentcar/domain/user/service/AdminService.java
@@ -4,27 +4,30 @@ import com.yu.yurentcar.domain.user.dto.AdminLoginDto;
 import com.yu.yurentcar.domain.user.entity.Admin;
 import com.yu.yurentcar.domain.user.repository.AdminRepository;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 @Log4j2
 @Service
 public class AdminService {
     private final AdminRepository adminRepository;
+    private final PasswordEncoder passwordEncoder;
 
-    public AdminService(AdminRepository adminRepository) {
+    public AdminService(AdminRepository adminRepository, PasswordEncoder passwordEncoder) {
         this.adminRepository = adminRepository;
+        this.passwordEncoder = passwordEncoder;
     }
 
     @Transactional(readOnly = true)
-    public Boolean loginAdmin(AdminLoginDto adminLoginDto) {
-        Optional<Admin> lookupAdmin = adminRepository.findByUsername(adminLoginDto.getUsername());
-        if (lookupAdmin.isEmpty()) throw new RuntimeException("존재하지 않는 아이디입니다.");
-        if (!lookupAdmin.get().getPassword().equals(adminLoginDto.getPassword()))
+    public Admin loginAdmin(AdminLoginDto adminLoginDto) {
+        Admin lookupAdmin = adminRepository.findByUsername(adminLoginDto.getUsername())
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 아이디입니다."));
+
+        if (!passwordEncoder.matches(adminLoginDto.getPassword(), lookupAdmin.getPassword()))
             throw new RuntimeException("입력하신 패스워드가 틀렸습니다.");
-        return true;
+
+        return lookupAdmin;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/yu/yurentcar/domain/user/service/CustomAdminDetailsService.java
+++ b/src/main/java/com/yu/yurentcar/domain/user/service/CustomAdminDetailsService.java
@@ -1,0 +1,45 @@
+package com.yu.yurentcar.domain.user.service;
+
+
+import com.yu.yurentcar.domain.user.dto.AdminAuthDto;
+import com.yu.yurentcar.domain.user.entity.Admin;
+import com.yu.yurentcar.domain.user.repository.AdminRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class CustomAdminDetailsService implements UserDetailsService {
+
+    private final AdminRepository adminRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        log.info("UserDetailsService loadUserByUsername " + username);
+
+        Admin admin = adminRepository.findByUsername(username).orElseThrow(() -> new RuntimeException("존재하지 않는 관리자입니다."));
+
+        log.info("---------------------------");
+        log.info(admin);
+
+        AdminAuthDto adminAuth = new AdminAuthDto(
+                admin.getUsername(),
+                admin.getPassword(),
+                admin.getBranch().getBranchId(),
+                admin.getBranch().getBranchName(),
+                Collections.singleton(new SimpleGrantedAuthority("ROLE_ADMIN"))
+        );
+
+        return adminAuth;
+    }
+
+
+}

--- a/src/main/java/com/yu/yurentcar/security/config/SecurityConfig.java
+++ b/src/main/java/com/yu/yurentcar/security/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.yu.yurentcar.security.config;
 
 import com.yu.yurentcar.domain.user.repository.UserRepository;
+import com.yu.yurentcar.domain.user.service.CustomAdminDetailsService;
 import com.yu.yurentcar.domain.user.service.CustomOAuth2UserService;
 import com.yu.yurentcar.domain.user.service.CustomUserDetailsService;
 import com.yu.yurentcar.global.utils.CookieProvider;
@@ -46,6 +47,7 @@ public class SecurityConfig {
 
     private final TokenRedisService tokenRedisService;
     private final CustomUserDetailsService customUserDetailsService;
+    private final CustomAdminDetailsService customAdminDetailsService;
 
     private final TokenProvider tokenProvider;
     private final CookieProvider cookieProvider;
@@ -81,7 +83,7 @@ public class SecurityConfig {
                 .sessionManagement()
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 
-        http.addFilterBefore(new JwtFilter(tokenProvider, customUserDetailsService), UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(new JwtFilter(tokenProvider, customUserDetailsService, customAdminDetailsService), UsernamePasswordAuthenticationFilter.class);
 
         http.authorizeHttpRequests((authz) -> authz
                 .requestMatchers("/api/v1/**").permitAll()
@@ -140,7 +142,7 @@ public class SecurityConfig {
     CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         //configuration.setAllowedOrigins(Collections.singletonList("http://42.82.185.184:3000")); // singletonList : 하나짜리 리스트
-        configuration.setAllowedOrigins(Arrays.asList(webBaseUrl, "http://localhost:3000"));
+        configuration.setAllowedOrigins(Arrays.asList(webBaseUrl, "http://localhost:3000", "http://localhost:3001"));
         configuration.setAllowedMethods(Collections.singletonList("*"));
         configuration.setAllowedHeaders(Collections.singletonList("*"));
         configuration.setExposedHeaders(Arrays.asList("X-Page-Count", "Access-Control-Allow-Origin","Access-Control-Allow-Credentials"));


### PR DESCRIPTION
- AdminController
  - 로그인 로직에 accessToken, refreshToken을 생성해서 추가해주도록 변경

- AdminLoginResponseDto
  - branchName: String
  - province: String

- AdminService
  - passwordEncoder로 비밀번호 일치여부 체크하도록 변경

- AdminAuthDto
  - exnteds User(security.core.userdeatils)
  - implements OAuth2User
  - security에서의 인증 유저로 사용하기 위함

- CustomAdminDetailsService
  - AdminAuthDto를 불러오는 Service

- JwtFilter
  - ROLE_USER, ROLE_ADMIN에 따라 AuthDto를 불러오는 분기처리

- SecurityConfig
  - CustomAdminDetailsService 주입

Related to : https://github.com/YU-RentCar/YURentCar-be/issues/125